### PR TITLE
修正projection(...)方法中，仅能使用最后一个key的问题

### DIFF
--- a/src/main/java/com/cybermkd/kit/MongoQuery.java
+++ b/src/main/java/com/cybermkd/kit/MongoQuery.java
@@ -301,9 +301,12 @@ public class MongoQuery {
 
 
     public MongoQuery projection(String... keys) {
+        BasicDBObject dbObj = new BasicDBObject();
         for (String key : keys) {
-            this.projection = new BasicDBObject().append(key, 1);
+            dbObj.append(key, 1);
         }
+
+        this.projection = dbObj;
         return this;
     }
 


### PR DESCRIPTION
在测试过程中发现，当执行如下的方法时：_List<JSONObject> students = new MongoQuery().use("student").eq("name", "燕夏岚").projection("teacherName", "score").find()_。在Debug过程中，观察到**MongoQuery**类的**projection**对象仅有最后一个key，而不是传入全部key的组合。
